### PR TITLE
Add delay in loading stack templates to avoid throttling by AWS

### DIFF
--- a/lib/stackInformation.js
+++ b/lib/stackInformation.js
@@ -79,7 +79,10 @@ module.exports = {
 	aliasStackLoadAliasTemplates() {
 
 		return this.aliasStackGetAliasStackNames()		// eslint-disable-line lodash/prefer-lodash-method
-		.mapSeries(stack => BbPromise.join(BbPromise.resolve(stack), this.aliasStackLoadTemplate(stack)))
+		.mapSeries(stack =>
+			new BbPromise.Promise(resolve => setTimeout(resolve, 1000))
+				.then(() => BbPromise.join(BbPromise.resolve(stack), this.aliasStackLoadTemplate(stack)))
+		)
 		.map(stackInfo => ({ stack: stackInfo[0], template: stackInfo[1] }))
 		.catch(err => {
 			if (err.statusCode === 400) {


### PR DESCRIPTION
When there are many (at least ~15) stacks for a given alias, the deployment can fail when `serverless-aws-alias` is trying to download all the templates for all the alias stacks. This appears to be AWS throttling the calls.

Example error log during serverless deployment:
```
Error --------------------------------------------------
 
  Unable to retrieve template for <stack-name>: 400
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
```

The proposed fix puts a delay between subsequent calls to AWS `CloudFormation:getTemplate`.